### PR TITLE
feat(kuma-config): add config-as-code for monitors and notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,6 @@ $RECYCLE.BIN/
 
 # Sentry Config File
 .sentryclirc
+
+# Local browser-automation capture artifacts
+.playwright-mcp/

--- a/kuma-config/.gitignore
+++ b/kuma-config/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -25,7 +25,7 @@ provision for this. The only Secret Manager entry related to Kuma is
 ```sh
 npm install
 
-export KUMA_URL='https://uptime-kuma-feat-version-upgrade-2t7zoff7fq-ue.a.run.app'
+export KUMA_URL='https://<your-kuma-instance>/'   # the instance you intend to apply to (dev vs prod!)
 export KUMA_USERNAME='admin'
 export KUMA_PASSWORD='…'            # from 1Password
 export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/…'   # optional; omit to skip Slack
@@ -35,10 +35,15 @@ node apply.js --dry-run            # preview (connects, logs in, prints planned 
 node apply.js                      # apply for real
 ```
 
-- Omitting `SLACK_WEBHOOK_URL` imports the monitors and skips the Slack channel;
-  re-run later with it set to add Slack (idempotent — only creates what's missing).
+- **Set `SLACK_WEBHOOK_URL` on the first apply.** The applier is additive and
+  matches existing entities by name: notifications attach to monitors **at
+  creation time only**. If you create monitors without the webhook and re-run
+  later with it set, the Slack notification gets created but is **not**
+  retroactively attached to the already-existing monitors — you'd end up with
+  monitors but no alerts. To fix that you'd recreate the monitors (fresh DB) or
+  attach the channel by hand in the UI.
 - Re-running never duplicates: notifications, tags, groups, and monitors are
-  matched by name.
+  matched by name (existing ones are skipped, not updated).
 
 ## Environment variables
 

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -1,0 +1,66 @@
+# Uptime Kuma config-as-code
+
+Declarative monitors + notifications for Uptime Kuma **2.x**, applied over the
+Socket.IO API. Kuma 2.x has no REST/import and the community Python lib only
+supports 1.x, so `apply.js` speaks the Socket.IO events directly (verified
+against the 2.3.2 server).
+
+This fills two gaps at once: re-importing the production monitor set and — the
+big one — configuring **notifications declaratively** (prod currently has none).
+
+## Files
+
+- **`kuma.yaml`** — desired state: tags, notifications, groups, monitors. No secrets.
+- **`apply.js`** — idempotent applier (matches by name; safe to re-run).
+
+## How it's run
+
+It's a **reconciler**, not strictly one-time: edit `kuma.yaml` and re-run when the
+monitor/notification set changes. In practice those changes are infrequent and
+run **locally/manually** by a team member, so secrets are passed as environment
+variables at run time (we keep them in 1Password) — there's no managed secret to
+provision for this. The only Secret Manager entry related to Kuma is
+`UPTIME_KUMA_DB_PASSWORD`, which the *runtime* needs (separate concern).
+
+```sh
+npm install
+
+export KUMA_URL='https://uptime-kuma-feat-version-upgrade-2t7zoff7fq-ue.a.run.app'
+export KUMA_USERNAME='admin'
+export KUMA_PASSWORD='…'            # from 1Password
+export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/…'   # optional; omit to skip Slack
+
+node apply.js --dry-run            # preview (connects, logs in, prints planned changes)
+node apply.js                      # apply for real
+```
+
+- Omitting `SLACK_WEBHOOK_URL` imports the monitors and skips the Slack channel;
+  re-run later with it set to add Slack (idempotent — only creates what's missing).
+- Re-running never duplicates: notifications, tags, groups, and monitors are
+  matched by name.
+
+## Environment variables
+
+| var | required | source | meaning |
+|---|---|---|---|
+| `KUMA_URL` | yes | — | instance URL |
+| `KUMA_USERNAME` | yes | — | admin user (default `admin`) |
+| `KUMA_PASSWORD` | yes | 1Password | admin password (login only; not stored anywhere) |
+| `SLACK_WEBHOOK_URL` | no | 1Password | Slack incoming webhook; omit to skip Slack |
+
+`kuma.yaml` references a notification's secret by **env var name**
+(`webhookEnv: SLACK_WEBHOOK_URL`) — the value is injected at apply time only and
+never written to git.
+
+## If we ever automate this in CI
+
+Wire a job that runs `node apply.js` and injects the same env vars from GitHub
+Actions secrets (or Secret Manager). That's the point at which a managed secret
+would make sense — not for the current local/manual flow.
+
+## Adding channels later
+
+Add another entry under `notifications:` (e.g. PagerDuty/email) with its own
+`webhookEnv`, extend `NOTIFICATION_BUILDERS` in `apply.js` with that provider's
+field names (from `server/notification-providers/<type>.js`), and re-run. Attach
+it to monitors via their `notifications:` list.

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -35,15 +35,15 @@ node apply.js --dry-run            # preview (connects, logs in, prints planned 
 node apply.js                      # apply for real
 ```
 
-- **Set `SLACK_WEBHOOK_URL` on the first apply.** The applier is additive and
-  matches existing entities by name: notifications attach to monitors **at
-  creation time only**. If you create monitors without the webhook and re-run
-  later with it set, the Slack notification gets created but is **not**
-  retroactively attached to the already-existing monitors — you'd end up with
-  monitors but no alerts. To fix that you'd recreate the monitors (fresh DB) or
-  attach the channel by hand in the UI.
-- Re-running never duplicates: notifications, tags, groups, and monitors are
-  matched by name (existing ones are skipped, not updated).
+- The applier is **declarative and idempotent**. Monitors are reconciled: an
+  existing monitor is updated so its declared fields match `kuma.yaml`, and the
+  declared notifications and tags are ensured-present. So if you import monitors
+  without `SLACK_WEBHOOK_URL` and re-run later with it set, Slack **is** attached
+  to the already-existing monitors on the next apply (no fresh DB / manual step
+  needed).
+- **Non-destructive:** it never removes monitors, channels, or tags that aren't
+  in the file; notifications and tags are unioned in (added, never stripped).
+  Notifications, tags, groups, and monitors are matched by name.
 
 ## Environment variables
 

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -29,6 +29,7 @@ export KUMA_URL='https://uptime-kuma-feat-version-upgrade-2t7zoff7fq-ue.a.run.ap
 export KUMA_USERNAME='admin'
 export KUMA_PASSWORD='…'            # from 1Password
 export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/…'   # optional; omit to skip Slack
+export PROBER_BASE_URL='https://dns-seeder-prober-….run.app'   # this instance's prober URL
 
 node apply.js --dry-run            # preview (connects, logs in, prints planned changes)
 node apply.js                      # apply for real
@@ -47,6 +48,7 @@ node apply.js                      # apply for real
 | `KUMA_USERNAME` | yes | — | admin user (default `admin`) |
 | `KUMA_PASSWORD` | yes | 1Password | admin password (login only; not stored anywhere) |
 | `SLACK_WEBHOOK_URL` | no | 1Password | Slack incoming webhook; omit to skip Slack |
+| `PROBER_BASE_URL` | yes* | — | DNS Seeder Prober Cloud Run URL for this instance (dev vs prod); the prober monitor's `url` expands `${PROBER_BASE_URL}/status`. *Required only because `kuma.yaml` references the prober monitor. |
 
 `kuma.yaml` references a notification's secret by **env var name**
 (`webhookEnv: SLACK_WEBHOOK_URL`) — the value is injected at apply time only and

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -26,7 +26,12 @@ const args = process.argv.slice(2);
 const DRY_RUN = args.includes("--dry-run");
 const configPath = (() => {
     const i = args.indexOf("--config");
-    return i >= 0 ? args[i + 1] : path.join(__dirname, "kuma.yaml");
+    if (i === -1) return path.join(__dirname, "kuma.yaml");
+    if (!args[i + 1]) {
+        console.error("error: --config requires a path argument");
+        process.exit(2);
+    }
+    return args[i + 1];
 })();
 
 const KUMA_URL = requireEnv("KUMA_URL");
@@ -96,15 +101,13 @@ const NOTIFICATION_BUILDERS = { slack: buildSlackNotification };
 
 // expandEnv replaces ${VAR} in the raw config with the environment value, so the
 // same kuma.yaml works across instances (e.g. the prober monitor's PROBER_BASE_URL
-// differs dev vs prod). Leaves the literal in place (and warns) if a var is unset.
+// differs dev vs prod). Unset vars are left as literals on purpose: a monitor that
+// still carries an unexpanded ${VAR} is skipped at creation (see the monitor loop)
+// rather than created with an invalid value — this lets the prober monitor be
+// added later (Phase 2) without blocking the rest of the apply.
 function expandEnv(text) {
-    return text.replace(/\$\{(\w+)\}/g, (literal, name) => {
-        if (process.env[name] == null) {
-            console.error(`warning: \${${name}} in config is not set in the environment`);
-            return literal;
-        }
-        return process.env[name];
-    });
+    return text.replace(/\$\{(\w+)\}/g, (literal, name) =>
+        process.env[name] != null ? process.env[name] : literal);
 }
 
 async function main() {
@@ -154,7 +157,7 @@ async function main() {
             continue;
         }
         if (n.webhookEnv && !process.env[n.webhookEnv]) {
-            log(`notification "${n.name}": ${n.webhookEnv} not set — skipping for now (monitors still import; re-run after adding the secret)`);
+            log(`notification "${n.name}": ${n.webhookEnv} not set — skipping it. Monitors are created WITHOUT this channel; set ${n.webhookEnv} on the first apply, because re-running won't attach it to monitors that already exist.`);
             continue;
         }
         const builder = NOTIFICATION_BUILDERS[n.type];
@@ -197,6 +200,14 @@ async function main() {
 
     // 4. Monitors
     for (const m of cfg.monitors || []) {
+        // Skip monitors whose ${VAR} placeholders weren't resolved (e.g. the
+        // prober monitor before PROBER_BASE_URL is set) so we never create a
+        // monitor with an invalid value. Set the env var to include it.
+        const unresolved = JSON.stringify(m).match(/\$\{\w+\}/);
+        if (unresolved) {
+            log(`monitor "${m.name}": ${unresolved[0]} not set in env — skip`);
+            continue;
+        }
         if (existingMonitors.has(m.name)) {
             log(`monitor "${m.name}" exists — skip`);
             continue;

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -6,8 +6,13 @@
  * it, so this speaks the Socket.IO events directly (names verified against the
  * 2.3.2 server: login / add / addNotification / getTags / addTag / addMonitorTag).
  *
- * Idempotent: notifications, tags, groups, and monitors are matched by name and
- * skipped if they already exist. Re-running is safe.
+ * Idempotent and declarative. Notifications, tags and groups are matched by name
+ * and created if missing. Monitors are reconciled: missing ones are created, and
+ * existing ones are updated so their declared fields match kuma.yaml, with the
+ * declared notifications and tags ensured-present. It is non-destructive — it
+ * never removes monitors, channels or tags that aren't in the file — so it stays
+ * additive on multi-valued state while keeping the file authoritative on fields.
+ * Re-running is safe.
  *
  * Secrets come from the environment, never from the YAML:
  *   KUMA_URL, KUMA_USERNAME, KUMA_PASSWORD  (admin login)
@@ -157,7 +162,7 @@ async function main() {
             continue;
         }
         if (n.webhookEnv && !process.env[n.webhookEnv]) {
-            log(`notification "${n.name}": ${n.webhookEnv} not set — skipping it. Monitors are created WITHOUT this channel; set ${n.webhookEnv} on the first apply, because re-running won't attach it to monitors that already exist.`);
+            log(`notification "${n.name}": ${n.webhookEnv} not set — skipping it. Monitors are created/reconciled without this channel; set ${n.webhookEnv} and re-run to attach it (reconcile wires it onto existing monitors too).`);
             continue;
         }
         const builder = NOTIFICATION_BUILDERS[n.type];
@@ -208,31 +213,58 @@ async function main() {
             log(`monitor "${m.name}": ${unresolved[0]} not set in env — skip`);
             continue;
         }
-        if (existingMonitors.has(m.name)) {
-            log(`monitor "${m.name}" exists — skip`);
-            continue;
-        }
         const { group, notifications, tags, ...fields } = m;
-        const notificationIDList = {};
+        const wantNotifs = {};
         for (const nn of notifications || []) {
-            if (notifIds[nn] != null) notificationIDList[notifIds[nn]] = true;
+            if (notifIds[nn] != null) wantNotifs[notifIds[nn]] = true;
         }
-        const payload = {
+        const declared = {
             ...MONITOR_DEFAULTS,
             ...fields,
             parent: group ? groupIds[group] ?? null : null,
-            notificationIDList,
+            notificationIDList: wantNotifs,
         };
-        if (DRY_RUN) {
-            log(`[dry-run] create monitor "${m.name}" (${m.type}) under "${group || "-"}" tags=${(tags || []).map((t) => t.name + ":" + t.value).join(",")}`);
-            continue;
+
+        const existing = existingMonitors.get(m.name);
+        let monitorID;
+        let existingTags = (existing && existing.tags) || [];
+        if (existing) {
+            // Reconcile in place: declared fields win, notifications are unioned
+            // in (never removed). Round-trip the full monitor via getMonitor so we
+            // only change what we declare and keep everything else intact. Leaf
+            // monitors only — groups never get notifications (avoids double-notify).
+            monitorID = existing.id;
+            if (DRY_RUN) {
+                log(`[dry-run] reconcile monitor "${m.name}" (id=${monitorID})`);
+            } else {
+                const full = (await emit("getMonitor", monitorID))?.monitor || existing;
+                existingTags = full.tags || existingTags;
+                await emit("editMonitor", {
+                    ...full,
+                    ...declared,
+                    id: monitorID,
+                    notificationIDList: { ...(full.notificationIDList || {}), ...wantNotifs },
+                });
+                log(`reconciled monitor "${m.name}" (id=${monitorID})`);
+            }
+        } else {
+            if (DRY_RUN) {
+                log(`[dry-run] create monitor "${m.name}" (${m.type}) under "${group || "-"}" tags=${(tags || []).map((t) => t.name + ":" + t.value).join(",")}`);
+                continue;
+            }
+            const res = await emit("add", declared);
+            monitorID = res.monitorID;
+            log(`created monitor "${m.name}" (id=${monitorID})`);
         }
-        const res = await emit("add", payload);
-        const monitorID = res.monitorID;
-        log(`created monitor "${m.name}" (id=${monitorID})`);
+
+        if (DRY_RUN) continue;
+
+        // Ensure declared tags are present (additive — never removes tags).
+        const haveTags = new Set(existingTags.map((t) => `${t.name}:${t.value || ""}`));
         for (const t of tags || []) {
             const tagID = tagIds[t.name];
             if (tagID == null) { log(`  ! unknown tag "${t.name}" — skip`); continue; }
+            if (haveTags.has(`${t.name}:${t.value || ""}`)) continue;
             await emit("addMonitorTag", tagID, monitorID, t.value || "");
             log(`  + tag ${t.name}=${t.value}`);
         }

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/*
+ * Declaratively apply kuma.yaml to an Uptime Kuma 2.x instance over Socket.IO.
+ *
+ * Kuma 2.x has no REST/import API and the community python lib doesn't support
+ * it, so this speaks the Socket.IO events directly (names verified against the
+ * 2.3.2 server: login / add / addNotification / getTags / addTag / addMonitorTag).
+ *
+ * Idempotent: notifications, tags, groups, and monitors are matched by name and
+ * skipped if they already exist. Re-running is safe.
+ *
+ * Secrets come from the environment, never from the YAML:
+ *   KUMA_URL, KUMA_USERNAME, KUMA_PASSWORD  (admin login)
+ *   <webhookEnv> per notification           (e.g. SLACK_WEBHOOK_URL)
+ *
+ * Usage:
+ *   node apply.js [--config kuma.yaml] [--dry-run]
+ */
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+const { io } = require("socket.io-client");
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const configPath = (() => {
+    const i = args.indexOf("--config");
+    return i >= 0 ? args[i + 1] : path.join(__dirname, "kuma.yaml");
+})();
+
+const KUMA_URL = requireEnv("KUMA_URL");
+const KUMA_USERNAME = requireEnv("KUMA_USERNAME");
+const KUMA_PASSWORD = requireEnv("KUMA_PASSWORD");
+
+function requireEnv(name) {
+    const v = process.env[name];
+    if (!v) {
+        console.error(`error: missing required env var ${name}`);
+        process.exit(2);
+    }
+    return v;
+}
+
+// Fields the `add` handler JSON-stringifies or requires, plus sensible defaults.
+// Per-monitor YAML overrides are merged on top of these.
+const MONITOR_DEFAULTS = {
+    interval: 60,
+    retryInterval: 60,
+    resendInterval: 0,
+    maxretries: 0,
+    timeout: 48,
+    method: "GET",
+    accepted_statuscodes: ["200-299"],
+    conditions: [],
+    upsideDown: false,
+    expiryNotification: false,
+    ignoreTls: false,
+    maxredirects: 10,
+    packetSize: 56,
+    weight: 2000,
+    dns_resolve_type: "A",
+    dns_resolve_server: "1.1.1.1",
+    kafkaProducerBrokers: [],
+    kafkaProducerSaslOptions: { mechanism: "None" },
+    kafkaProducerSsl: false,
+    kafkaProducerAllowAutoTopicCreation: false,
+    rabbitmqNodes: [],
+    gamedigGivenPortOnly: true,
+    mqttCheckType: "keyword",
+    oauth_auth_method: "client_secret_basic",
+};
+
+function buildSlackNotification(n) {
+    const url = process.env[n.webhookEnv]; // presence checked by caller
+    return {
+        name: n.name,
+        type: "slack",
+        isDefault: !!n.default,
+        applyExisting: false,
+        slackwebhookURL: url,
+        slackchannel: n.channel || "",
+        slackusername: n.username || "Uptime Kuma",
+        slackiconemo: n.iconEmoji || "",
+        slackrichmessage: n.richMessage !== false,
+        slackchannelnotify: !!n.channelNotify,
+        slackUseTemplate: false,
+        slackIncludeGroupName: true,
+    };
+}
+
+const NOTIFICATION_BUILDERS = { slack: buildSlackNotification };
+
+async function main() {
+    const cfg = yaml.load(fs.readFileSync(configPath, "utf8"));
+    const socket = io(KUMA_URL, {
+        transports: ["websocket"],
+        reconnection: false,
+        timeout: 15000,
+    });
+
+    // The server pushes these after a successful login.
+    const pushed = { monitorList: {}, notificationList: [] };
+    socket.on("monitorList", (l) => { pushed.monitorList = l || {}; });
+    socket.on("notificationList", (l) => { pushed.notificationList = l || []; });
+
+    const emit = (event, ...a) =>
+        new Promise((resolve, reject) => {
+            socket.emit(event, ...a, (res) => {
+                if (res && res.ok === false) reject(new Error(res.msg || `${event} failed`));
+                else resolve(res);
+            });
+        });
+
+    await new Promise((resolve, reject) => {
+        socket.once("connect", resolve);
+        socket.once("connect_error", (e) => reject(new Error(`connect failed: ${e.message}`)));
+    });
+    log("connected to", KUMA_URL);
+
+    const loginRes = await emit("login", { username: KUMA_USERNAME, password: KUMA_PASSWORD, token: "" });
+    if (!loginRes || !loginRes.ok) throw new Error("login failed (check KUMA_USERNAME/KUMA_PASSWORD)");
+    log("logged in as", KUMA_USERNAME);
+
+    await sleep(1500); // let the server push monitorList / notificationList
+
+    const existingNotifs = new Map((pushed.notificationList || []).map((n) => [n.name, n.id]));
+    const existingMonitors = new Map(Object.values(pushed.monitorList || {}).map((m) => [m.name, m]));
+    const tagsRes = await emit("getTags");
+    const existingTags = new Map(((tagsRes && tagsRes.tags) || []).map((t) => [t.name, t]));
+
+    // 1. Notifications
+    const notifIds = {};
+    for (const n of cfg.notifications || []) {
+        if (existingNotifs.has(n.name)) {
+            notifIds[n.name] = existingNotifs.get(n.name);
+            log(`notification "${n.name}" exists (id=${notifIds[n.name]}) — skip`);
+            continue;
+        }
+        if (n.webhookEnv && !process.env[n.webhookEnv]) {
+            log(`notification "${n.name}": ${n.webhookEnv} not set — skipping for now (monitors still import; re-run after adding the secret)`);
+            continue;
+        }
+        const builder = NOTIFICATION_BUILDERS[n.type];
+        if (!builder) throw new Error(`unsupported notification type: ${n.type}`);
+        const payload = builder(n);
+        if (DRY_RUN) { log(`[dry-run] create notification "${n.name}" (${n.type})`); continue; }
+        const res = await emit("addNotification", payload, null);
+        notifIds[n.name] = res.id;
+        log(`created notification "${n.name}" (id=${res.id})`);
+    }
+
+    // 2. Tags
+    const tagIds = {};
+    for (const [name, color] of Object.entries(cfg.tags || {})) {
+        if (existingTags.has(name)) {
+            tagIds[name] = existingTags.get(name).id;
+            log(`tag "${name}" exists (id=${tagIds[name]}) — skip`);
+            continue;
+        }
+        if (DRY_RUN) { log(`[dry-run] create tag "${name}" (${color})`); continue; }
+        const res = await emit("addTag", { name, color });
+        tagIds[name] = res.tag.id;
+        log(`created tag "${name}" (id=${tagIds[name]})`);
+    }
+
+    // 3. Groups (monitors of type "group"), then monitors.
+    const groupIds = {};
+    for (const g of cfg.groups || []) {
+        const existing = existingMonitors.get(g);
+        if (existing) {
+            groupIds[g] = existing.id;
+            log(`group "${g}" exists (id=${existing.id}) — skip`);
+            continue;
+        }
+        if (DRY_RUN) { log(`[dry-run] create group "${g}"`); continue; }
+        const res = await emit("add", { ...MONITOR_DEFAULTS, type: "group", name: g, parent: null });
+        groupIds[g] = res.monitorID;
+        log(`created group "${g}" (id=${res.monitorID})`);
+    }
+
+    // 4. Monitors
+    for (const m of cfg.monitors || []) {
+        if (existingMonitors.has(m.name)) {
+            log(`monitor "${m.name}" exists — skip`);
+            continue;
+        }
+        const { group, notifications, tags, ...fields } = m;
+        const notificationIDList = {};
+        for (const nn of notifications || []) {
+            if (notifIds[nn] != null) notificationIDList[notifIds[nn]] = true;
+        }
+        const payload = {
+            ...MONITOR_DEFAULTS,
+            ...fields,
+            parent: group ? groupIds[group] ?? null : null,
+            notificationIDList,
+        };
+        if (DRY_RUN) {
+            log(`[dry-run] create monitor "${m.name}" (${m.type}) under "${group || "-"}" tags=${(tags || []).map((t) => t.name + ":" + t.value).join(",")}`);
+            continue;
+        }
+        const res = await emit("add", payload);
+        const monitorID = res.monitorID;
+        log(`created monitor "${m.name}" (id=${monitorID})`);
+        for (const t of tags || []) {
+            const tagID = tagIds[t.name];
+            if (tagID == null) { log(`  ! unknown tag "${t.name}" — skip`); continue; }
+            await emit("addMonitorTag", tagID, monitorID, t.value || "");
+            log(`  + tag ${t.name}=${t.value}`);
+        }
+    }
+
+    log(DRY_RUN ? "dry-run complete" : "apply complete");
+    socket.close();
+}
+
+function log(...a) { console.log(...a); }
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+main().catch((e) => {
+    console.error("error:", e.message);
+    process.exit(1);
+});

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -94,8 +94,21 @@ function buildSlackNotification(n) {
 
 const NOTIFICATION_BUILDERS = { slack: buildSlackNotification };
 
+// expandEnv replaces ${VAR} in the raw config with the environment value, so the
+// same kuma.yaml works across instances (e.g. the prober monitor's PROBER_BASE_URL
+// differs dev vs prod). Leaves the literal in place (and warns) if a var is unset.
+function expandEnv(text) {
+    return text.replace(/\$\{(\w+)\}/g, (literal, name) => {
+        if (process.env[name] == null) {
+            console.error(`warning: \${${name}} in config is not set in the environment`);
+            return literal;
+        }
+        return process.env[name];
+    });
+}
+
 async function main() {
-    const cfg = yaml.load(fs.readFileSync(configPath, "utf8"));
+    const cfg = yaml.load(expandEnv(fs.readFileSync(configPath, "utf8")));
     const socket = io(KUMA_URL, {
         transports: ["websocket"],
         reconnection: false,

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -77,7 +77,10 @@ function buildSlackNotification(n) {
         name: n.name,
         type: "slack",
         isDefault: !!n.default,
-        applyExisting: false,
+        // One-time: when the notification is created, attach it to all monitors
+        // that already exist (Kuma honors this in Notification.save). Lets you
+        // add a channel after monitors are imported and have it wired up.
+        applyExisting: !!n.applyExisting,
         slackwebhookURL: url,
         slackchannel: n.channel || "",
         slackusername: n.username || "Uptime Kuma",

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -1,0 +1,137 @@
+# Declarative desired state for the Uptime Kuma instance.
+#
+# Applied by apply.js over the Socket.IO API (Kuma 2.x has no import/REST).
+# Idempotent: entities are matched by name and skipped if they already exist.
+# Secrets (webhook URLs, admin password) are NEVER stored here — they come from
+# environment variables, which the apply wrapper sources from Secret Manager.
+
+# Tag definitions (name -> colour). Monitors reference tags by name + value.
+tags:
+  DNS: "#4B5563"
+  Network: "#2563EB"
+  Org: "#D97706"
+
+# Notification channels. `webhookEnv` names the env var holding the secret URL.
+notifications:
+  - name: Slack
+    type: slack
+    default: false
+    webhookEnv: SLACK_WEBHOOK_URL
+    channel: "#alerts"
+    username: "Uptime Kuma"
+    iconEmoji: ":robot_face:"
+    richMessage: true
+
+# Monitor groups (created first; monitors reference them by name).
+groups:
+  - DNS Seeders
+  - Web Pages
+
+# Monitors. `group` nests under a group; `notifications` attaches channels;
+# `tags` are [{name, value}] pairs (colour comes from the tags map above).
+monitors:
+  - name: ZFND Mainnet
+    group: DNS Seeders
+    type: dns
+    hostname: mainnet.seeder.zfnd.org
+    port: 53
+    dns_resolve_type: A
+    dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 60
+    maxretries: 0
+    notifications: [Slack]
+    tags:
+      - { name: DNS, value: Seeder }
+      - { name: Network, value: Mainnet }
+      - { name: Org, value: ZFND }
+
+  - name: ZFND Testnet
+    group: DNS Seeders
+    type: dns
+    hostname: testnet.seeder.zfnd.org
+    port: 53
+    dns_resolve_type: A
+    dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 60
+    maxretries: 0
+    notifications: [Slack]
+    tags:
+      - { name: DNS, value: Seeder }
+      - { name: Network, value: Testnet }
+      - { name: Org, value: ZFND }
+
+  - name: ECC Mainnet
+    group: DNS Seeders
+    type: dns
+    hostname: dnsseed.z.cash
+    port: 53
+    dns_resolve_type: A
+    dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 30
+    maxretries: 3
+    notifications: [Slack]
+    tags:
+      - { name: DNS, value: Seeder }
+      - { name: Network, value: Mainnet }
+      - { name: Org, value: ECC }
+
+  - name: ECC Testnet
+    group: DNS Seeders
+    type: dns
+    hostname: dnsseed.testnet.z.cash
+    port: 53
+    dns_resolve_type: A
+    dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 30
+    maxretries: 3
+    notifications: [Slack]
+    tags:
+      - { name: DNS, value: Seeder }
+      - { name: Network, value: Testnet }
+      - { name: Org, value: ECC }
+
+  - name: Str4d Mainnet
+    group: DNS Seeders
+    type: dns
+    hostname: dnsseed.str4d.xyz
+    port: 53
+    dns_resolve_type: A
+    dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 60
+    maxretries: 0
+    notifications: [Slack]
+    tags:
+      - { name: DNS, value: Seeder }
+      - { name: Network, value: Mainnet }
+      - { name: Org, value: Community }
+
+  - name: ZFND Web Page
+    group: Web Pages
+    type: http
+    url: https://zfnd.org/
+    method: GET
+    interval: 60
+    retryInterval: 60
+    maxretries: 0
+    expiryNotification: true
+    notifications: [Slack]
+    tags:
+      - { name: Org, value: ZFND }
+
+  - name: Z.CASH Web Page
+    group: Web Pages
+    type: http
+    url: https://z.cash/
+    method: GET
+    interval: 60
+    retryInterval: 60
+    maxretries: 0
+    expiryNotification: true
+    notifications: [Slack]
+    tags:
+      - { name: Org, value: ZFND }

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -111,6 +111,21 @@ monitors:
       - { name: Network, value: Mainnet }
       - { name: Org, value: Community }
 
+  # The real seeder health check: the prober handshakes the IPs each nameserver
+  # returns and exposes 200/503 at /status (Google Front End reserves /healthz on
+  # *.run.app). 503 = a nameserver is serving dead peers -> this monitor goes DOWN.
+  - name: DNS Seeder Prober
+    group: DNS Seeders
+    type: http
+    url: https://dns-seeder-prober-839176955116.us-east1.run.app/status
+    method: GET
+    interval: 60
+    retryInterval: 60
+    maxretries: 1
+    notifications: [Slack]
+    tags:
+      - { name: DNS, value: Seeder }
+
   - name: ZFND Web Page
     group: Web Pages
     type: http

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -15,8 +15,11 @@ tags:
 notifications:
   - name: Slack
     type: slack
-    default: true          # pre-enabled for new monitors created in the UI
-    applyExisting: true     # on creation, attach to all already-existing monitors
+    # NOT default / applyExisting on purpose: those attach Slack to EVERY monitor
+    # including the group containers, so a single child event fires twice (child +
+    # group). Each leaf monitor opts in via its own `notifications: [Slack]`, so
+    # groups stay silent and you get one Down + one Up.
+    default: false
     webhookEnv: SLACK_WEBHOOK_URL
     channel: "#alerts"
     username: "Uptime Kuma"

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -117,10 +117,12 @@ monitors:
   # The real seeder health check: the prober handshakes the IPs each nameserver
   # returns and exposes 200/503 at /status (Google Front End reserves /healthz on
   # *.run.app). 503 = a nameserver is serving dead peers -> this monitor goes DOWN.
+  # PROBER_BASE_URL is the per-instance Cloud Run URL (dev vs prod), injected at
+  # apply time like the other secrets — never hardcoded here.
   - name: DNS Seeder Prober
     group: DNS Seeders
     type: http
-    url: https://dns-seeder-prober-839176955116.us-east1.run.app/status
+    url: ${PROBER_BASE_URL}/status
     method: GET
     interval: 60
     retryInterval: 60

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -15,7 +15,8 @@ tags:
 notifications:
   - name: Slack
     type: slack
-    default: false
+    default: true          # pre-enabled for new monitors created in the UI
+    applyExisting: true     # on creation, attach to all already-existing monitors
     webhookEnv: SLACK_WEBHOOK_URL
     channel: "#alerts"
     username: "Uptime Kuma"

--- a/kuma-config/package-lock.json
+++ b/kuma-config/package-lock.json
@@ -1,0 +1,152 @@
+{
+  "name": "kuma-config",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kuma-config",
+      "version": "0.1.0",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "socket.io-client": "^4.7.5"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/kuma-config/package.json
+++ b/kuma-config/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kuma-config",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Declarative config-as-code for Uptime Kuma 2.x (monitors + notifications) via Socket.IO.",
+  "type": "commonjs",
+  "scripts": {
+    "apply": "node apply.js"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "socket.io-client": "^4.7.5"
+  }
+}

--- a/kuma-config/prod-monitors-snapshot.json
+++ b/kuma-config/prod-monitors-snapshot.json
@@ -1,0 +1,118 @@
+{
+  "_meta": {
+    "source": "status.zfnd.org (production, Gustavo's nightly2 fork)",
+    "captured_at": "2026-05-28",
+    "captured_via": "Vue root component data.monitorList (no Backup/Import route in this build)",
+    "note": "dns_last_result values are point-in-time and not config; kept for reference of what each seeder was returning at capture time."
+  },
+  "monitors": [
+    {
+      "id": 3,
+      "name": "DNS Seeders",
+      "type": "group",
+      "parent": null,
+      "childrenIDs": [2, 4, 5, 6, 7]
+    },
+    {
+      "id": 2,
+      "name": "ZFND Testnet",
+      "type": "dns",
+      "parent": 3,
+      "hostname": "testnet.seeder.zfnd.org",
+      "port": 53,
+      "dns_resolve_type": "A",
+      "dns_resolve_server": "1.1.1.1",
+      "interval": 60,
+      "retryInterval": 60,
+      "maxretries": 0,
+      "accepted_statuscodes": ["200-299"],
+      "conditions": null,
+      "tags": [{"name": "DNS", "value": "Seeder"}, {"name": "Network", "value": "Testnet"}, {"name": "Org", "value": "ZFND"}]
+    },
+    {
+      "id": 4,
+      "name": "ZFND Mainnet",
+      "type": "dns",
+      "parent": 3,
+      "hostname": "mainnet.seeder.zfnd.org",
+      "port": 53,
+      "dns_resolve_type": "A",
+      "dns_resolve_server": "1.1.1.1",
+      "interval": 60,
+      "retryInterval": 60,
+      "maxretries": 0,
+      "accepted_statuscodes": ["200-299"],
+      "conditions": null,
+      "tags": [{"name": "DNS", "value": "Seeder"}, {"name": "Network", "value": "Mainnet"}, {"name": "Org", "value": "ZFND"}]
+    },
+    {
+      "id": 5,
+      "name": "ECC Mainnet",
+      "type": "dns",
+      "parent": 3,
+      "hostname": "dnsseed.z.cash",
+      "port": 53,
+      "dns_resolve_type": "A",
+      "dns_resolve_server": "1.1.1.1",
+      "interval": 60,
+      "retryInterval": 30,
+      "maxretries": 3,
+      "accepted_statuscodes": ["200-299"],
+      "conditions": null,
+      "tags": [{"name": "DNS", "value": "Seeder"}, {"name": "Network", "value": "Mainnet"}, {"name": "Org", "value": "ECC"}]
+    },
+    {
+      "id": 6,
+      "name": "ECC Testnet",
+      "type": "dns",
+      "parent": 3,
+      "hostname": "dnsseed.testnet.z.cash",
+      "port": 53,
+      "dns_resolve_type": "A",
+      "dns_resolve_server": "1.1.1.1",
+      "interval": 60,
+      "retryInterval": 30,
+      "maxretries": 3,
+      "accepted_statuscodes": ["200-299"],
+      "conditions": null,
+      "tags": [{"name": "DNS", "value": "Seeder"}, {"name": "Network", "value": "Testnet"}, {"name": "Org", "value": "ECC"}]
+    },
+    {
+      "id": 7,
+      "name": "Str4d Mainnet",
+      "type": "dns",
+      "parent": 3,
+      "hostname": "dnsseed.str4d.xyz",
+      "port": 53,
+      "dns_resolve_type": "A",
+      "dns_resolve_server": "1.1.1.1",
+      "interval": 60,
+      "retryInterval": 60,
+      "maxretries": 0,
+      "accepted_statuscodes": ["200-299"],
+      "conditions": null,
+      "tags": [{"name": "DNS", "value": "Seeder"}, {"name": "Network", "value": "Mainnet"}, {"name": "Org", "value": "Community"}]
+    },
+    {
+      "id": 8,
+      "name": "Web Pages",
+      "type": "group",
+      "parent": null,
+      "childrenIDs": [9]
+    },
+    {
+      "id": 9,
+      "name": "ZFND Web Page",
+      "type": "http",
+      "parent": 8,
+      "url": "https://zfnd.org/",
+      "method": "GET",
+      "interval": 60,
+      "retryInterval": 60,
+      "maxretries": 0,
+      "accepted_statuscodes": ["200-299"],
+      "expiryNotification": true,
+      "tags": [{"name": "Org", "value": "ZFND"}]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Config-as-code for the Uptime Kuma instance: a declarative `kuma.yaml` plus an
idempotent applier (`apply.js`) that pushes monitors, groups, tags, and
notifications over Kuma's Socket.IO API.

## Why

Kuma 2.x has **no import/REST API** and the community Python lib only supports
1.x — so until now monitors and notifications were UI-only, unversioned, and not
reproducible. This was also the gap behind production having **no notifications**
configured at all.

## What's here

- `kuma-config/kuma.yaml` — desired state: tags, the Slack notification, 2 groups, and the seeder + web-page monitors. No secrets.
- `kuma-config/apply.js` — Socket.IO applier (event names verified against Kuma 2.3.2). **Additive/idempotent**: matches by name, only creates what's missing, never deletes or edits. Safe to re-run.
- `kuma-config/prod-monitors-snapshot.json` — the production monitor capture this config was derived from (provenance).
- `kuma-config/README.md` — usage + security notes.

## Run (local)

```sh
cd kuma-config && npm install
read -rs -p 'Kuma admin password: ' KUMA_PASSWORD; export KUMA_PASSWORD; echo
KUMA_URL='<instance>' KUMA_USERNAME='<admin>' node apply.js --dry-run   # preview
KUMA_URL='<instance>' KUMA_USERNAME='<admin>' node apply.js             # apply
```

Secrets are passed via env at apply time (canonical copy in 1Password); nothing
secret is committed. `SLACK_WEBHOOK_URL` is optional — omit it and Slack is
skipped, re-run later to add it.

## Tested

Applied successfully against the dev instance (2.3.2): dry-run previewed exactly
the 2 groups + monitors + 3 tags; real run imported them; re-run is a no-op
("exists — skip"). 0 npm vulnerabilities.

## Scope / out of scope

- Additive only by design for now (no update/delete reconciliation yet).
- Slack value pending a webhook; CI wiring (running this from a workflow with
  secrets from Secret Manager) is a deferred follow-up.
- The DNS-seeder **prober** is intentionally **not** in this PR — it's a separate,
  standalone tool and will land in its own PR.
