### PR TITLE
ci(prod): deploy Kuma on internal-and-cloud-load-balancing ingress

### DIFF
--- a/.github/workflows/cd-deploy-to-prod.yml
+++ b/.github/workflows/cd-deploy-to-prod.yml
@@ -62,4 +62,5 @@ jobs:
       no_cpu_throttling: true
       # LB-only (status.zfnd.org); direct *.run.app URL closed.
       ingress: internal-and-cloud-load-balancing
+      public_url: https://status.zfnd.org
     secrets: inherit

--- a/.github/workflows/cd-deploy-to-prod.yml
+++ b/.github/workflows/cd-deploy-to-prod.yml
@@ -60,4 +60,6 @@ jobs:
       # Uptime Kuma runs a continuous background monitoring loop; keep CPU
       # always allocated so prod isn't throttled/disconnected between requests.
       no_cpu_throttling: true
+      # LB-only (status.zfnd.org); direct *.run.app URL closed.
+      ingress: internal-and-cloud-load-balancing
     secrets: inherit

--- a/.github/workflows/sub-cloudrun-deploy.yml
+++ b/.github/workflows/sub-cloudrun-deploy.yml
@@ -54,6 +54,11 @@ on:
         type: string
         default: all
         description: Cloud Run ingress (all | internal-and-cloud-load-balancing).
+      public_url:
+        required: false
+        type: string
+        default: ''
+        description: External URL (e.g. the LB domain) used for the Environment URL and smoke test when the *.run.app URL is closed.
 
 # NOTE: do not use `read-all`. As a reusable workflow this may not request more
 # permissions than the caller grants, and `read-all` now expands to include newer
@@ -88,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}
-      url: ${{ steps.deploy.outputs.url }}
+      url: ${{ inputs.public_url || steps.deploy.outputs.url }}
     permissions:
       contents: read
       id-token: write
@@ -151,7 +156,7 @@ jobs:
           gcloud run services add-iam-policy-binding ${{ inputs.app_name }}-${{ needs.versioning.outputs.version || env.GITHUB_HEAD_REF_SLUG || inputs.environment }} \
           --region=${{ inputs.region }} --member=allUsers --role=roles/run.invoker --quiet
 
-      # The *.run.app URL is closed under internal ingress.
+      # Use the public URL (LB) when the *.run.app URL is closed under internal ingress.
       - name: Test service with cURL
-        if: ${{ inputs.ingress == 'all' }}
-        run: curl "${{ steps.deploy.outputs.url }}"
+        if: ${{ inputs.public_url != '' || inputs.ingress == 'all' }}
+        run: curl --retry 5 --retry-all-errors -fsSL "${{ inputs.public_url || steps.deploy.outputs.url }}" -o /dev/null

--- a/.github/workflows/sub-cloudrun-deploy.yml
+++ b/.github/workflows/sub-cloudrun-deploy.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}
-      url: ${{ inputs.public_url || steps.deploy.outputs.url }}
+      url: ${{ inputs.ingress == 'all' && steps.deploy.outputs.url || inputs.public_url }}
     permissions:
       contents: read
       id-token: write
@@ -118,6 +118,14 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2.1.0
+
+      # Restricted ingress closes the *.run.app URL, so we need public_url for the
+      # Environment URL and smoke test — fail fast instead of silently skipping it.
+      - name: Require public_url for restricted ingress
+        if: ${{ inputs.ingress != 'all' && inputs.public_url == '' }}
+        run: |
+          echo "::error::ingress=${{ inputs.ingress }} requires public_url (the *.run.app URL is closed)"
+          exit 1
 
       - name: Deploy to cloud run
         id: deploy
@@ -156,7 +164,7 @@ jobs:
           gcloud run services add-iam-policy-binding ${{ inputs.app_name }}-${{ needs.versioning.outputs.version || env.GITHUB_HEAD_REF_SLUG || inputs.environment }} \
           --region=${{ inputs.region }} --member=allUsers --role=roles/run.invoker --quiet
 
-      # Use the public URL (LB) when the *.run.app URL is closed under internal ingress.
+      # Curl the reachable URL: the direct one for `all`, else the public LB URL
+      # (guaranteed present by the guard above).
       - name: Test service with cURL
-        if: ${{ inputs.public_url != '' || inputs.ingress == 'all' }}
-        run: curl --retry 5 --retry-all-errors -fsSL "${{ inputs.public_url || steps.deploy.outputs.url }}" -o /dev/null
+        run: curl --retry 5 --retry-all-errors --max-time 30 -fsSL "${{ inputs.ingress == 'all' && steps.deploy.outputs.url || inputs.public_url }}" -o /dev/null

--- a/.github/workflows/sub-cloudrun-deploy.yml
+++ b/.github/workflows/sub-cloudrun-deploy.yml
@@ -49,6 +49,11 @@ on:
           Allocate CPU for the full instance lifetime (instance-based billing).
           Required for always-on workloads like Uptime Kuma, whose background
           monitoring loop is otherwise throttled/disconnected between requests.
+      ingress:
+        required: false
+        type: string
+        default: all
+        description: Cloud Run ingress (all | internal-and-cloud-load-balancing).
 
 # NOTE: do not use `read-all`. As a reusable workflow this may not request more
 # permissions than the caller grants, and `read-all` now expands to include newer
@@ -132,6 +137,7 @@ jobs:
             --cpu=${{ inputs.cpu }}
             --memory=${{ inputs.memory }}
             ${{ inputs.no_cpu_throttling && '--no-cpu-throttling' || '' }}
+            --ingress=${{ inputs.ingress }}
             --service-account=${{ vars.GCP_BUCKET_SA }}
             --set-cloudsql-instances=${{ vars.CLOUDSQL_INSTANCE }}
             --add-volume=name=files,type=in-memory
@@ -139,11 +145,13 @@ jobs:
             --network=${{ vars.GCP_NETWORK }}
             --subnet=${{ vars.GCP_SUBNETWORK }}
 
+      # Required even with internal ingress: the LB invokes Cloud Run unauthenticated.
       - name: Allow unauthenticated calls to the service
-        if: ${{ inputs.environment != 'prod' }}
         run: |
           gcloud run services add-iam-policy-binding ${{ inputs.app_name }}-${{ needs.versioning.outputs.version || env.GITHUB_HEAD_REF_SLUG || inputs.environment }} \
           --region=${{ inputs.region }} --member=allUsers --role=roles/run.invoker --quiet
 
+      # The *.run.app URL is closed under internal ingress.
       - name: Test service with cURL
+        if: ${{ inputs.ingress == 'all' }}
         run: curl "${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
Makes the prod Kuma service reachable **only through the external HTTPS LB** (status.zfnd.org); the direct `*.run.app` URL is closed.

- New `ingress` input (default `all`); prod passes `internal-and-cloud-load-balancing`.
- `allUsers` runs for prod too — the LB's invoke permission, not public access.
- New `public_url` input (prod: `https://status.zfnd.org`) used for the Environment URL and the smoke test.
- URL is selected by ingress: direct `*.run.app` when `all`, else `public_url`. The deploy **fails fast** if restricted ingress has no `public_url` (so the smoke test is never silently skipped). cURL is capped with `--max-time`.

Depends on cloud-foundation-fabric org-policy overrides. Only affects future deploys; current v2 stays `all` during the cutover.