### PR TITLE
fix(kuma-config): add retries + lower timeout to stop false-down alerts

### DIFF
--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -53,8 +53,9 @@ function requireEnv(name) {
 }
 
 // Fields the `add` handler JSON-stringifies or requires, plus sensible defaults.
-// Per-monitor YAML overrides are merged on top of these. retries=3 + 20s timeout
-// require a sustained failure (~60s) before Down, filtering transient blips.
+// Per-monitor YAML overrides are merged on top of these. maxretries + a short
+// timeout require a sustained failure (not a one-off blip) before Down, which
+// filters the transient timeouts that were firing false alerts.
 const MONITOR_DEFAULTS = {
     interval: 60,
     retryInterval: 20,

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -61,7 +61,7 @@ const MONITOR_DEFAULTS = {
     retryInterval: 20,
     resendInterval: 0,
     maxretries: 3,
-    timeout: 20,
+    timeout: 15,
     method: "GET",
     accepted_statuscodes: ["200-299"],
     conditions: [],

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -53,9 +53,10 @@ function requireEnv(name) {
 }
 
 // Fields the `add` handler JSON-stringifies or requires, plus sensible defaults.
-// Per-monitor YAML overrides are merged on top of these. maxretries + a short
-// timeout require a sustained failure (not a one-off blip) before Down, which
-// filters the transient timeouts that were firing false alerts.
+// Per-monitor YAML overrides are merged on top of these. maxretries makes Down
+// require several consecutive failures (not a one-off blip) — that's what filters
+// the transient timeouts that fired false alerts; the shorter timeout only caps
+// how long each attempt waits.
 const MONITOR_DEFAULTS = {
     interval: 60,
     retryInterval: 20,

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -53,13 +53,14 @@ function requireEnv(name) {
 }
 
 // Fields the `add` handler JSON-stringifies or requires, plus sensible defaults.
-// Per-monitor YAML overrides are merged on top of these.
+// Per-monitor YAML overrides are merged on top of these. retries=3 + 20s timeout
+// require a sustained failure (~60s) before Down, filtering transient blips.
 const MONITOR_DEFAULTS = {
     interval: 60,
-    retryInterval: 60,
+    retryInterval: 20,
     resendInterval: 0,
-    maxretries: 0,
-    timeout: 48,
+    maxretries: 3,
+    timeout: 20,
     method: "GET",
     accepted_statuscodes: ["200-299"],
     conditions: [],

--- a/kuma-config/apply.js
+++ b/kuma-config/apply.js
@@ -53,10 +53,11 @@ function requireEnv(name) {
 }
 
 // Fields the `add` handler JSON-stringifies or requires, plus sensible defaults.
-// Per-monitor YAML overrides are merged on top of these. maxretries makes Down
-// require several consecutive failures (not a one-off blip) — that's what filters
-// the transient timeouts that fired false alerts; the shorter timeout only caps
-// how long each attempt waits.
+// Merged into every monitor payload (per-monitor YAML overrides win). maxretries
+// makes Down require several consecutive failures (not a one-off blip) — that's
+// what filters the transient timeouts that fired false alerts. timeout only
+// affects HTTP checks (Kuma ignores it for DNS) and is kept < retryInterval so
+// each attempt finishes before the next retry.
 const MONITOR_DEFAULTS = {
     interval: 60,
     retryInterval: 20,

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -41,9 +41,6 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
-    interval: 60
-    retryInterval: 60
-    maxretries: 0
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -57,9 +54,6 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
-    interval: 60
-    retryInterval: 60
-    maxretries: 0
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -73,9 +67,6 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
-    interval: 60
-    retryInterval: 30
-    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -89,9 +80,6 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
-    interval: 60
-    retryInterval: 30
-    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -105,9 +93,6 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
-    interval: 60
-    retryInterval: 60
-    maxretries: 0
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -124,9 +109,6 @@ monitors:
     type: http
     url: ${PROBER_BASE_URL}/status
     method: GET
-    interval: 60
-    retryInterval: 60
-    maxretries: 1
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -136,9 +118,6 @@ monitors:
     type: http
     url: https://zfnd.org/
     method: GET
-    interval: 60
-    retryInterval: 60
-    maxretries: 0
     expiryNotification: true
     notifications: [Slack]
     tags:
@@ -149,9 +128,6 @@ monitors:
     type: http
     url: https://z.cash/
     method: GET
-    interval: 60
-    retryInterval: 60
-    maxretries: 0
     expiryNotification: true
     notifications: [Slack]
     tags:

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -31,8 +31,10 @@ groups:
   - DNS Seeders
   - Web Pages
 
-# Monitors. `group` nests under a group; `notifications` attaches channels;
-# `tags` are [{name, value}] pairs (colour comes from the tags map above).
+# Monitors. Each declares its own interval/retries so the desired state is
+# explicit here, not hidden in defaults. `timeout` only affects HTTP monitors —
+# Kuma ignores it for DNS, so the DNS ones omit it. `group` nests under a group;
+# `notifications` attaches channels; `tags` are [{name, value}] pairs.
 monitors:
   - name: ZFND Mainnet
     group: DNS Seeders
@@ -41,6 +43,9 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -54,6 +59,9 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -67,6 +75,9 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -80,6 +91,9 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -93,6 +107,9 @@ monitors:
     port: 53
     dns_resolve_type: A
     dns_resolve_server: 1.1.1.1
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -109,6 +126,10 @@ monitors:
     type: http
     url: ${PROBER_BASE_URL}/status
     method: GET
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
+    timeout: 15
     notifications: [Slack]
     tags:
       - { name: DNS, value: Seeder }
@@ -118,6 +139,10 @@ monitors:
     type: http
     url: https://zfnd.org/
     method: GET
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
+    timeout: 15
     expiryNotification: true
     notifications: [Slack]
     tags:
@@ -128,6 +153,10 @@ monitors:
     type: http
     url: https://z.cash/
     method: GET
+    interval: 60
+    retryInterval: 20
+    maxretries: 3
+    timeout: 15
     expiryNotification: true
     notifications: [Slack]
     tags:

--- a/kuma-config/kuma.yaml
+++ b/kuma-config/kuma.yaml
@@ -32,9 +32,10 @@ groups:
   - Web Pages
 
 # Monitors. Each declares its own interval/retries so the desired state is
-# explicit here, not hidden in defaults. `timeout` only affects HTTP monitors —
-# Kuma ignores it for DNS, so the DNS ones omit it. `group` nests under a group;
-# `notifications` attaches channels; `tags` are [{name, value}] pairs.
+# explicit here, not hidden in defaults. DNS monitors don't declare `timeout`
+# because Kuma only uses it for HTTP checks (the applier still sends the default,
+# harmlessly). `group` nests under a group; `notifications` attaches channels;
+# `tags` are [{name, value}] pairs.
 monitors:
   - name: ZFND Mainnet
     group: DNS Seeders


### PR DESCRIPTION
**Problem:** intermittent false `Down` alerts (`timeout of 48000ms exceeded`, recovering ~1 min later). Root cause: the web-page and several DNS monitors had `maxretries: 0` — a single transient timeout fired an instant Down + Slack, with no re-check.

**Fix:** tune the monitor thresholds and declare them **explicitly per monitor** in `kuma.yaml` (desired state lives in the file, not hidden in the applier defaults):
- `interval: 60`, `retryInterval: 20`, `maxretries: 3` on every monitor.
- `timeout: 15` on **HTTP** monitors only (prober + web pages). DNS monitors omit it — Kuma ignores the timeout field for DNS. Timeout is kept `< retryInterval` so each attempt finishes before the next retry.
- `MONITOR_DEFAULTS` in `apply.js` keeps these as a fallback for new monitors.

A real sustained outage now needs several consecutive failures before alerting; a one-off blip is retried and ignored. Values are uniform for now (validated appropriate for both DNS and HTTP); per-monitor differentiation is easy since they're explicit.

Applied via the config-as-code pipeline on merge (or `node apply.js`).