### PR TITLE
ci: add config-as-code apply pipeline

### DIFF
--- a/.github/workflows/cd-apply-kuma-config.yml
+++ b/.github/workflows/cd-apply-kuma-config.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod
     timeout-minutes: 10
+    # Only ever reconcile prod from main — a workflow_dispatch on a feature branch
+    # must not apply unmerged kuma-config to prod.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4.1.7
         with:
@@ -50,6 +53,7 @@ jobs:
           KUMA_USERNAME: ${{ vars.KUMA_USERNAME }}
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
+          set -euo pipefail
           KUMA_PASSWORD="$(gcloud secrets versions access latest --secret=UPTIME_KUMA_ADMIN_PASSWORD --project="$GCP_PROJECT")"
           SLACK_WEBHOOK_URL="$(gcloud secrets versions access latest --secret=SLACK_WEBHOOK_URL --project="$GCP_PROJECT")"
           echo "::add-mask::$KUMA_PASSWORD"

--- a/.github/workflows/cd-apply-kuma-config.yml
+++ b/.github/workflows/cd-apply-kuma-config.yml
@@ -23,6 +23,7 @@ jobs:
   apply:
     runs-on: ubuntu-latest
     environment: prod
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4.1.7
         with:
@@ -33,6 +34,7 @@ jobs:
         with:
           workload_identity_provider: ${{ vars.GCP_WIF }}
           service_account: ${{ vars.GCP_KUMA_APPLIER_SA }}
+          project_id: ${{ vars.GCP_PROJECT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2.1.0
@@ -46,8 +48,12 @@ jobs:
         env:
           KUMA_URL: ${{ vars.KUMA_PUBLIC_URL }}
           KUMA_USERNAME: ${{ vars.KUMA_USERNAME }}
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
-          export KUMA_PASSWORD="$(gcloud secrets versions access latest --secret=UPTIME_KUMA_ADMIN_PASSWORD --project=${{ vars.GCP_PROJECT }})"
-          export SLACK_WEBHOOK_URL="$(gcloud secrets versions access latest --secret=SLACK_WEBHOOK_URL --project=${{ vars.GCP_PROJECT }})"
+          KUMA_PASSWORD="$(gcloud secrets versions access latest --secret=UPTIME_KUMA_ADMIN_PASSWORD --project="$GCP_PROJECT")"
+          SLACK_WEBHOOK_URL="$(gcloud secrets versions access latest --secret=SLACK_WEBHOOK_URL --project="$GCP_PROJECT")"
+          echo "::add-mask::$KUMA_PASSWORD"
+          echo "::add-mask::$SLACK_WEBHOOK_URL"
+          export KUMA_PASSWORD SLACK_WEBHOOK_URL
           npm ci
           node apply.js

--- a/.github/workflows/cd-apply-kuma-config.yml
+++ b/.github/workflows/cd-apply-kuma-config.yml
@@ -1,0 +1,53 @@
+name: Apply Kuma config
+
+# Reconciles kuma-config/ onto the prod Kuma (status.zfnd.org) on merge to main.
+# apply.js is declarative and non-destructive. Manual re-run via workflow_dispatch.
+# Auth: WIF (keyless) -> a least-privilege SA that reads the admin/webhook secrets
+# from Secret Manager. No secrets are stored in GitHub.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'kuma-config/**'
+  workflow_dispatch:
+
+concurrency:
+  group: apply-kuma-config
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2.1.3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF }}
+          service_account: ${{ vars.GCP_KUMA_APPLIER_SA }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2.1.0
+
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: '20'
+
+      - name: Apply config-as-code
+        working-directory: kuma-config
+        env:
+          KUMA_URL: ${{ vars.KUMA_PUBLIC_URL }}
+          KUMA_USERNAME: ${{ vars.KUMA_USERNAME }}
+        run: |
+          export KUMA_PASSWORD="$(gcloud secrets versions access latest --secret=UPTIME_KUMA_ADMIN_PASSWORD --project=${{ vars.GCP_PROJECT }})"
+          export SLACK_WEBHOOK_URL="$(gcloud secrets versions access latest --secret=SLACK_WEBHOOK_URL --project=${{ vars.GCP_PROJECT }})"
+          npm ci
+          node apply.js

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -59,11 +59,19 @@ node apply.js                      # apply for real
 (`webhookEnv: SLACK_WEBHOOK_URL`) — the value is injected at apply time only and
 never written to git.
 
-## If we ever automate this in CI
+## Pipeline (prod)
 
-Wire a job that runs `node apply.js` and injects the same env vars from GitHub
-Actions secrets (or Secret Manager). That's the point at which a managed secret
-would make sense — not for the current local/manual flow.
+Merging a change under `kuma-config/` to `main` runs
+[`cd-apply-kuma-config.yml`](../.github/workflows/cd-apply-kuma-config.yml), which
+reconciles the prod Kuma over `status.zfnd.org`. Re-run manually from the Actions
+tab (`workflow_dispatch`).
+
+Secrets are **not** stored in GitHub. The job authenticates with **Workload
+Identity Federation** (keyless) as a least-privilege SA (`kuma-config-applier`)
+that holds only `secretAccessor` on the two secrets it reads, and pulls
+`UPTIME_KUMA_ADMIN_PASSWORD` + `SLACK_WEBHOOK_URL` from **Secret Manager** at run
+time — single source of truth, one rotation point. GitHub only holds non-secret
+`prod` vars: `KUMA_PUBLIC_URL`, `KUMA_USERNAME`.
 
 ## Adding channels later
 

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -63,7 +63,7 @@ never written to git.
 
 Merging a change under `kuma-config/` to `main` runs
 [`cd-apply-kuma-config.yml`](../.github/workflows/cd-apply-kuma-config.yml), which
-reconciles the prod Kuma over `status.zfnd.org`. Re-run manually from the Actions
+reconciles the prod Kuma at `status.zfnd.org`. Re-run manually from the Actions
 tab (`workflow_dispatch`).
 
 Secrets are **not** stored in GitHub. The job authenticates with **Workload
@@ -71,7 +71,8 @@ Identity Federation** (keyless) as a least-privilege SA (`kuma-config-applier`)
 that holds only `secretAccessor` on the two secrets it reads, and pulls
 `UPTIME_KUMA_ADMIN_PASSWORD` + `SLACK_WEBHOOK_URL` from **Secret Manager** at run
 time — single source of truth, one rotation point. GitHub only holds non-secret
-`prod` vars: `KUMA_PUBLIC_URL`, `KUMA_USERNAME`.
+`prod` vars: `KUMA_PUBLIC_URL` (the workflow maps it to `apply.js`'s `KUMA_URL`)
+and `KUMA_USERNAME`.
 
 ## Adding channels later
 

--- a/kuma-config/README.md
+++ b/kuma-config/README.md
@@ -66,13 +66,25 @@ Merging a change under `kuma-config/` to `main` runs
 reconciles the prod Kuma at `status.zfnd.org`. Re-run manually from the Actions
 tab (`workflow_dispatch`).
 
-Secrets are **not** stored in GitHub. The job authenticates with **Workload
-Identity Federation** (keyless) as a least-privilege SA (`kuma-config-applier`)
-that holds only `secretAccessor` on the two secrets it reads, and pulls
-`UPTIME_KUMA_ADMIN_PASSWORD` + `SLACK_WEBHOOK_URL` from **Secret Manager** at run
-time — single source of truth, one rotation point. GitHub only holds non-secret
-`prod` vars: `KUMA_PUBLIC_URL` (the workflow maps it to `apply.js`'s `KUMA_URL`)
-and `KUMA_USERNAME`.
+**No secrets live in GitHub.** The job authenticates with keyless **Workload
+Identity Federation** as a least-privilege service account (`kuma-config-applier`,
+which holds only `secretAccessor` on the two secrets it reads) and pulls the admin
+password and Slack webhook from **Secret Manager** at run time — one source of
+truth, one rotation point.
+
+To operate it, the `prod` GitHub environment provides these non-secret
+**variables** (secret *values* stay in Secret Manager):
+
+| Variable | Purpose |
+|---|---|
+| `KUMA_PUBLIC_URL` | Kuma instance URL, mapped to `apply.js`'s `KUMA_URL` |
+| `KUMA_USERNAME` | Kuma admin username |
+| `GCP_PROJECT` | GCP project that holds the secrets |
+| `GCP_WIF` | Workload Identity provider (keyless auth) |
+| `GCP_KUMA_APPLIER_SA` | Service account the job impersonates |
+
+Secrets read from Secret Manager (never GitHub): `UPTIME_KUMA_ADMIN_PASSWORD`,
+`SLACK_WEBHOOK_URL`.
 
 ## Adding channels later
 


### PR DESCRIPTION
Reconciles `kuma-config/` onto the prod Kuma (status.zfnd.org) on merge to `main`, or via `workflow_dispatch`. `apply.js` is declarative and non-destructive.

Auth is keyless Workload Identity Federation as a least-privilege SA that reads the admin/webhook secrets from Secret Manager at run time — no secrets stored in GitHub.