### PR TITLE
ci(clean-dev): skip delete when the dev service doesn't exist

### DIFF
--- a/.github/workflows/chore-clean-dev.yml
+++ b/.github/workflows/chore-clean-dev.yml
@@ -30,4 +30,12 @@ jobs:
 
       - name: Removing CR service
         run: |
-          gcloud run services delete ${{ vars.APP_NAME }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }} --region=${{ vars.GCP_REGION }} --quiet
+          svc="${{ vars.APP_NAME }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}"
+          # Only branches that deployed a preview Kuma have a service; skip the rest
+          # (config/dependabot PRs, branch deletes) instead of failing on "not found".
+          if gcloud run services describe "$svc" --region="${{ vars.GCP_REGION }}" >/dev/null 2>&1; then
+            gcloud run services delete "$svc" --region="${{ vars.GCP_REGION }}" --quiet
+            echo "deleted $svc"
+          else
+            echo "no dev service '$svc' — nothing to clean"
+          fi


### PR DESCRIPTION
`chore-clean-dev` ran `gcloud run services delete uptime-kuma-<slug>` on every PR close / branch delete, so it **failed** for branches that never deployed a preview Kuma (config-as-code PRs, dependabot bumps, and the `delete`/main events → `uptime-kuma-main`). Harmless (nothing to clean) but noisy red ❌ in Actions.

Fix: describe the service first and skip if it doesn't exist, instead of erroring under `bash -e`.