### PR TITLE
fix(docker): run Kuma as the non-root node user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,10 +8,11 @@ ENV UPTIME_KUMA_IS_CONTAINER=1
 
 EXPOSE ${PORT}
 
-# The upstream uptime-kuma image is designed to run as root: it manages its own
-# data directory and child processes, and a non-root USER breaks startup. We
-# inherit that here intentionally, so skip the non-root-user policy.
-# checkov:skip=CKV_DOCKER_3:upstream uptime-kuma image runs as root by design
+# Run as the image's built-in node user (uid 1000). Upstream pre-chowns
+# /app/data to node, and 2.3.2 starts clean as non-root (verified: HTTP up,
+# extra/healthcheck OK, DB written). Cloud Run's in-memory volume is a tmpfs
+# writable by any uid, so the /app/data mount keeps working.
+USER node
 
 # Reuse Uptime Kuma's built-in healthcheck (same as the upstream image).
 HEALTHCHECK --interval=60s --timeout=30s --start-period=180s --retries=5 \


### PR DESCRIPTION
Closes #38.

The old comment claimed upstream "breaks as non-root" — tested and false for 2.3.2. The upstream image defaults to root only for bind-mount convenience: it ships a `node` user (uid 1000) with `/app/data` already chowned to it.

## Change
- `USER node` in `docker/Dockerfile`, replacing the checkov skip (both CKV_DOCKER_3 and Trivy DS-0002 now pass on merit instead of suppression).

## Verification (local Docker, image built from this branch)
- Process runs as `uid=1000(node)`; HTTP responds; `extra/healthcheck` returns 200; container `HEALTHCHECK` reports `healthy`.
- `/app/data` writes verified on a tmpfs mount replicating Cloud Run's in-memory volume (tmpfs is world-writable, so uid 1000 writes fine).
- Negative test for completeness: with a root-owned 755 mount Kuma does fail (`EACCES` on `data/upload/`) — that's the scenario the old comment generalized from; it doesn't apply to our volume type.

The dev preview deploy on this PR exercises the real Cloud Run path (deploy + cURL smoke test) as the final confirmation.